### PR TITLE
Fix Ratings/Missing seasons/episode info for plex web version 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Available at https://chrome.google.com/webstore/detail/plexius/cghenlijcboahfbcg
 
 changelog:
 
+1.5.4
+ - Fix ratings/missing season/episodes on web version 3.11.0
+
 1.5.3
  - put back the imdb rating
  - fixed rating styling

--- a/js/content.js
+++ b/js/content.js
@@ -1,12 +1,12 @@
 var settings;
 var global_server_addresses;
 var server_addresses = {};
-var criticRatingRtEl = "div[class^='CriticRating-rt'], div[class*=' CriticRating-rt']";
-var titleRatingContainerEl = "div[class^='PrePlayRatingRightTitle-ratingRightTitle-'], div[class*=' PrePlayRatingRightTitle-ratingRightTitle-']";
-var titleCriticRatingContainerEl = "span[class^='PrePlayRatingRightTitle-criticRating'], span[class*=' PrePlayRatingRightTitle-criticRating']";
-var criticRatingContainerEl = "div[class^='CriticRating-container-'], div[class*=' CriticRating-container-']";
-var imdbRatingContainerEl = "div[class^='CriticRating-imdb-'], div[class*=' CriticRating-imdb-']";
-var headerToolbarContainerEl = "div[class^='pageHeaderToolbar-toolbar-'], div[class*=' pageHeaderToolbar-toolbar-']";
+var criticRatingRtEl = "div[class^='CriticRating-rt'], div[class*=' CriticRating-rt'], div[class^='Zm7_X'],div[class*='Zm7_X']";
+var titleRatingContainerEl = "div[class^='PrePlayRatingRightTitle-ratingRightTitle-'], div[class*=' PrePlayRatingRightTitle-ratingRightTitle-'], div[class^='_1d4Yy'], div[class*='_1d4Yy']";
+var titleCriticRatingContainerEl = "span[class^='PrePlayRatingRightTitle-criticRating'], span[class*=' PrePlayRatingRightTitle-criticRating'], span[class^='_2J_tn'], span[class*='_2J_tn']";
+var criticRatingContainerEl = "div[class^='CriticRating-container-'], div[class*=' CriticRating-container-'], div[class^='_2t5Lw'], div[class*='_2t5Lw']";
+var imdbRatingContainerEl = "div[class^='CriticRating-imdb-'], div[class*=' CriticRating-imdb-'], div[class^='_16xaH'], div[class*='_16xaH']";
+var headerToolbarContainerEl = "div[class^='pageHeaderToolbar-toolbar-'], div[class*=' pageHeaderToolbar-toolbar-'], div[class^='_1lW-M'], div[class*='_1lW-M']";
 var task_counter = 0;
 var server;
 

--- a/js/plugins/missingEpisodes.js
+++ b/js/plugins/missingEpisodes.js
@@ -109,12 +109,12 @@ var missingEpisodes = {
     injectData: function(showName, episodes, resourceType) {
         if (episodes.aired.length) {
             if (!jQuery('.plex-missing-episodes').length) {
-                jQuery('<span class="plex-missing-episodes"> - <span>' + episodes.aired.length + ' missing</span></span>').appendTo("div[class^='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class*='PrePlayDescendantList-descendantHubCellHeader'] > div");
+                jQuery('<span class="plex-missing-episodes"> - <span>' + episodes.aired.length + ' missing</span></span>').appendTo("div[class^='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class*='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class^='_2qK3U'] > div, div[class*='_2qK3U'] > div");
             }
         }
         if (episodes.unaired.length) {
             if (!jQuery('.plex-unaired-episodes').length) {
-                jQuery('<span class="plex-unaired-episodes"> - <span>' + episodes.unaired.length + ' unaired</span></span>').appendTo("div[class^='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class*='PrePlayDescendantList-descendantHubCellHeader'] > div");
+                jQuery('<span class="plex-unaired-episodes"> - <span>' + episodes.unaired.length + ' unaired</span></span>').appendTo("div[class^='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class*='PrePlayDescendantList-descendantHubCellHeader'] > div, div[class^='_2qK3U'] > div, div[class*='_2qK3U'] > div");
             }
         }
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Plexius",
     "description": "Some enhancements to the Plex web interface",
-    "version": "1.5.3",
+    "version": "1.5.4",
 
     "browser_action": {
         "default_icon": "assets/icon.png"


### PR DESCRIPTION
Added new classes for the web version 3.11, this fixes both issue #6 and issue #7, have tested a bit and everything seems to be in working order at least on my end. (Can't promise they will work when 3.12+ releases but I'll be keeping an eye on the "https://app.plex.tv/web" releases as I have a stylesheet that I have to keep updated as well.)

Went ahead and upped the version # to 1.5.4 but you can change that if you want.